### PR TITLE
Supersede CONTRIBUTING, polish a bit.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,33 +1,8 @@
----
-title: Contributing Documentation to AAS WorldWide Telescope
-permalink: "/contributing/"
-nav_order: 2
----
+# Contributing to AAS WorldWide Telescope
 
-# Contributing Documentation to AAS WorldWide Telescope
-
-We would love for you to contribute to the WorldWide Telescope’s documentation!
-
-# How to Contribute
-
-Just submit a pull request, or file an issue if you’d like to discuss an idea
-before starting work!
-
-## Framework
-
-Our documentation is written in
-[Markdown](https://en.wikipedia.org/wiki/Markdown) (with the file extension
-`.md`) and rendered with [Gitbook](https://www.gitbook.com/). This means each
-repository has a `SUMMARY.md` table of contents file in addition to a
-`README.md` file that serves as an introduction to the documentation.
-
-## Contributing Agreement
-
-By contributing, you agree that we may redistribute your work under a
-[CC0 1.0 Universal license](LICENSE). Everyone involved in WorldWide Telescope
-agrees to abide by our [code of conduct](./CODE_OF_CONDUCT.md).
-
-## Acknowledgement
-
-This document is derived from documents from the AngularJS and Software
-Carpentry projects.
+Contributions to this repository, and the AAS WorldWide Telescope in general,
+are welcome! Please see
+[the Contributors’ Guide](https://worldwidetelescope.github.io/contributing/)
+for information. In the case of this repository, see in particular the section
+on
+[contributing documentation](https://worldwidetelescope.github.io/contributing/#writing-documentation).

--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
+  - CONTRIBUTING.md # canonical version is in `worldwidetelescope.github.io`

--- a/index.md
+++ b/index.md
@@ -35,6 +35,7 @@ WWT’s simple and powerful user interface.
 | Multi-Channel Dome Guide | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-multi-channel-dome-setup/content/) | [worldwide-telescope-multi-channel-dome-setup](https://github.com/WorldWideTelescope/worldwide-telescope-multi-channel-dome-setup) |
 | Importing NASA SPICE Kernel Data into WorldWide Telescope | [HTML](https://astrodavid.gitbooks.io/importing-spice-kernel-data-to-worldwide-telescop/content/) | none? |
 | Using WorldWide Telescope to produce Science Shorts | [HTML](https://doctorspaceman.gitbooks.io/using-worldwide-telescope-to-produce-science-shor/content/) | none? |
+| Project Code of Conduct | [HTML](./CODE_OF_CONDUCT.md) | [wwt-documentation](https://github.com/WorldWideTelescope/wwt-documentation) |
 
 ## Get Involved
 

--- a/index.md
+++ b/index.md
@@ -25,6 +25,7 @@ WWT’s simple and powerful user interface.
 |-- | -- | -- |
 | User Manual | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-user-manual/content/) | [worldwide-telescope-manual](https://github.com/WorldWideTelescope/worldwide-telescope-manual) |
 | pywwt Manual and API Reference | [HTML](https://pywwt.readthedocs.io/) | [pywwt](https://github.com/WorldWideTelescope/pywwt) |
+| Contributors’ Guide | [HTML](https://worldwidetelescope.github.io/contributing/) | [worldwidetelescope.github.io](https://github.com/WorldWideTelescope/worldwidetelescope.github.io) |
 | HTML5 Scripting Reference | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-web-control-script-reference/content/) | [worldwide-telescope-web-control-script-reference](https://github.com/WorldWideTelescope/worldwide-telescope-web-control-script-reference) |
 | Layer Control API Documentation | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-layer-control-api/content/) | [WorldWide-Telescope-Layer-Control-API](https://github.com/WorldWideTelescope/WorldWide-Telescope-Layer-Control-API) |
 | Projection Reference | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-projection-reference/content/) | [worldwide-telescope-projection-reference](https://github.com/WorldWideTelescope/worldwide-telescope-projection-reference) |

--- a/index.md
+++ b/index.md
@@ -38,7 +38,7 @@ WWT’s simple and powerful user interface.
 ## Get Involved
 
 We would love your help in making our documentation better! Please read our
-[contributing guide](./CONTRIBUTING.md) for more information. The source code
-for this site lives at the
+[Contributors’ Guide](https://worldwidetelescope.github.io/contributing/) for
+more information. The source code for this site lives at the
 [wwt-documentation](https://github.com/WorldWideTelescope/wwt-documentation)
 repository.

--- a/index.md
+++ b/index.md
@@ -24,6 +24,7 @@ WWT’s simple and powerful user interface.
 | Document | Rendered | Repository |
 |-- | -- | -- |
 | User Manual | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-user-manual/content/) | [worldwide-telescope-manual](https://github.com/WorldWideTelescope/worldwide-telescope-manual) |
+| pywwt Manual and API Reference | [HTML](https://pywwt.readthedocs.io/) | [pywwt](https://github.com/WorldWideTelescope/pywwt) |
 | HTML5 Scripting Reference | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-web-control-script-reference/content/) | [worldwide-telescope-web-control-script-reference](https://github.com/WorldWideTelescope/worldwide-telescope-web-control-script-reference) |
 | Layer Control API Documentation | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-layer-control-api/content/) | [WorldWide-Telescope-Layer-Control-API](https://github.com/WorldWideTelescope/WorldWide-Telescope-Layer-Control-API) |
 | Projection Reference | [HTML](https://worldwidetelescope.gitbooks.io/worldwide-telescope-projection-reference/content/) | [worldwide-telescope-projection-reference](https://github.com/WorldWideTelescope/worldwide-telescope-projection-reference) |


### PR DESCRIPTION
Add pywwt and the CoC.

We're a bit inconsistent in that the canonical version of the CoC lives in this repo, while the canonical version of the Contributors' guide lives in the `worldwidetelescope.github.io` repo, but whatever.